### PR TITLE
Update top-pypi-packages filename

### DIFF
--- a/tools/install_all_pip.py
+++ b/tools/install_all_pip.py
@@ -7,8 +7,8 @@ import urllib.request
 
 from tqdm import tqdm
 
-URL = 'https://hugovk.github.io/top-pypi-packages/top-pypi-packages-30-days.json'
-FILENAME = 'top-pypi-packages-30-days.json'
+URL = 'https://hugovk.github.io/top-pypi-packages/top-pypi-packages.json'
+FILENAME = 'top-pypi-packages.json'
 ABS_FILE = os.path.join(os.path.dirname(__file__), FILENAME)
 BLACKLIST = {
     'typing-extensions',


### PR DESCRIPTION
To stay within quota, it now has just under 30 days of data, so the filename has been updated. Both will be available for a while. See https://github.com/hugovk/top-pypi-packages/pull/46.